### PR TITLE
fix spelling errors within ctpl_stl

### DIFF
--- a/ctpl_stl.h
+++ b/ctpl_stl.h
@@ -184,7 +184,7 @@ namespace ctpl {
         }
 
         // run the user's function that excepts argument int - id of the running thread. returned value is templatized
-        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        // operator returns std::future, where the user can get the result and rethrow the caught exceptions
         template<typename F>
         auto push(F && f) ->std::future<decltype(f(0))> {
             auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));


### PR DESCRIPTION
This is just a trivial change to the spelling 