### PR TITLE
Fixed compilation error from including header file in angle brackets instead of double quotes

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -1,4 +1,4 @@
-#include <ctpl.h>
+#include "ctpl.h"
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
Some compilers (gcc 12 in my case) give compilation error if local header file is included to "example.cpp" with angle brackets. Only header files from system include paths should be included like that.